### PR TITLE
Set BUNDLE_GEMFILE during prepare step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.5.2
+===
+- Set `BUNDLE_GEMFILE` during prepare step so bundler doesn't complain when we try to call `Bundler.app_config_path`.
+
 0.5.1
 ===
 - Remove pry-byebug require.

--- a/lib/prebundler/cli/install.rb
+++ b/lib/prebundler/cli/install.rb
@@ -19,6 +19,7 @@ module Prebundler
 
       def prepare
         FileUtils.mkdir_p(bundle_path)
+        ENV['BUNDLE_GEMFILE'] = gemfile_path
 
         gem_list.each do |name, gem_ref|
           next if backend_file_list.include?(gem_ref.tar_file)

--- a/lib/prebundler/version.rb
+++ b/lib/prebundler/version.rb
@@ -1,3 +1,3 @@
 module Prebundler
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
Set `BUNDLE_GEMFILE` during prepare step so bundler doesn't complain when we try to call `Bundler.app_config_path`.