### PR TITLE
Minio Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.10.0
+===
+- Update aws-sdk client creation to be able to support non-aws s3 api endpoints (e.g. minio)
+
 0.9.1
 ===
 - Woops, also use platform version when determining the gems that have already been built.

--- a/lib/prebundler/s3_backend.rb
+++ b/lib/prebundler/s3_backend.rb
@@ -2,13 +2,15 @@ require 'aws-sdk'
 
 module Prebundler
   class S3Backend
-    attr_reader :access_key_id, :secret_access_key, :bucket, :region
+    attr_reader :access_key_id, :secret_access_key, :bucket, :region, :endpoint, :force_path_style
 
     def initialize(options = {})
       @access_key_id = options.fetch(:access_key_id)
       @secret_access_key = options.fetch(:secret_access_key)
       @bucket = options.fetch(:bucket)
-      @region = options.fetch(:region)
+      @region = options.fetch(:region) { 'us-east-1' }
+      @endpoint = options.fetch(:endpoint) { 's3.amazonaws.com' }
+      @force_path_style = options.fetch(:force_path_style) { false }
     end
 
     def store_file(source_file, dest_file)
@@ -60,7 +62,7 @@ module Prebundler
     private
 
     def client
-      @client ||= Aws::S3::Client.new(region: region, credentials: credentials)
+      @client ||= Aws::S3::Client.new(region: region, credentials: credentials, endpoint: endpoint, force_path_style: force_path_style)
     end
 
     def credentials

--- a/lib/prebundler/version.rb
+++ b/lib/prebundler/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prebundler
-  VERSION = '0.9.1'
+  VERSION = '0.10.0'
 end

--- a/test.rb
+++ b/test.rb
@@ -1,9 +1,0 @@
-def test(one:, two: nil)
-    puts "one: #{one}"
-    puts "two: #{two}"
-end
-
-test({}.tap do |o|
-    o[:one] = 1
-    o[:two] = ENV["TEST_TWO"] if ENV["TEST_TWO"]
-end)

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,9 @@
+def test(one:, two: nil)
+    puts "one: #{one}"
+    puts "two: #{two}"
+end
+
+test({}.tap do |o|
+    o[:one] = 1
+    o[:two] = ENV["TEST_TWO"] if ENV["TEST_TWO"]
+end)


### PR DESCRIPTION
Minio is an s3 api compatible object store. The aws-sdk for ruby supports it, but we need to be able to set the `endpoint` and force path style urls rather than domain style (using `force_path_style`).

Also set some defaults for some config values.