### PR TITLE
Pass in aws client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Gemfile.lock
 .DS_Store
 pkg/
+.prebundle_config
+*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.10.0
+===
+- Update aws-sdk client creation to be able to support non-aws s3 api endpoints (e.g. minio)
+
 0.9.1
 ===
 - Woops, also use platform version when determining the gems that have already been built.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 0.11.0
 ===
-- Refactor how aws credentials are gathered.
-  - If the caller wants to pass creds, use them
-  - Otherwise, let aws figure out how to get the credentials using their standards
-  - Also support assumed role creds
+- Allow the caller to pass in a s3 client for non-standard setups
 
 0.10.0
 ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.11.0
+===
+- Refactor how aws credentials are gathered.
+  - If the caller wants to pass creds, use them
+  - Otherwise, let aws figure out how to get the credentials using their standards
+  - Also support assumed role creds
+
 0.10.0
 ===
 - Update aws-sdk client creation to be able to support non-aws s3 api endpoints (e.g. minio)

--- a/lib/prebundler/s3_backend.rb
+++ b/lib/prebundler/s3_backend.rb
@@ -2,13 +2,15 @@ require 'aws-sdk'
 
 module Prebundler
   class S3Backend
-    attr_reader :access_key_id, :secret_access_key, :bucket, :region
+    attr_reader :access_key_id, :secret_access_key, :bucket, :region, :endpoint, :force_path_style
 
     def initialize(options = {})
       @access_key_id = options.fetch(:access_key_id)
       @secret_access_key = options.fetch(:secret_access_key)
       @bucket = options.fetch(:bucket)
-      @region = options.fetch(:region)
+      @region = options.fetch(:region) { 'us-east-1' }
+      @endpoint = options.fetch(:endpoint) { 's3.amazonaws.com' }
+      @force_path_style = options.fetch(:force_path_style) { false }
     end
 
     def store_file(source_file, dest_file)
@@ -60,7 +62,7 @@ module Prebundler
     private
 
     def client
-      @client ||= Aws::S3::Client.new(region: region, credentials: credentials)
+      @client ||= Aws::S3::Client.new(region: region, credentials: credentials, endpoint: endpoint, force_path_style: force_path_style)
     end
 
     def credentials

--- a/lib/prebundler/version.rb
+++ b/lib/prebundler/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Prebundler
-  VERSION = '0.9.1'
+  VERSION = '0.10.0'
 end

--- a/lib/prebundler/version.rb
+++ b/lib/prebundler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prebundler
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
~AWS credentials can come from a bunch of sources. Rather than only supporting passing credentials from the caller, let's be a bit more flexible:~

- ~If given a role arn, then use AssumedRole creds, using passed credentials if supplied~
- ~If just given creds, use them directly~
- ~Fallback to using SharedCredentials and have the AWS client figure it out from there~

Allow the caller to pass in an s3 client so non-standard setups can be supported ad nauseam